### PR TITLE
Faet/#21 usage api

### DIFF
--- a/src/main/java/com/posicube/assignment/querylog/adapter/out/persistence/QueryLogJpaEntity.java
+++ b/src/main/java/com/posicube/assignment/querylog/adapter/out/persistence/QueryLogJpaEntity.java
@@ -7,7 +7,6 @@ import lombok.*;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Entity

--- a/src/main/java/com/posicube/assignment/querylog/adapter/out/persistence/QueryLogJpaEntity.java
+++ b/src/main/java/com/posicube/assignment/querylog/adapter/out/persistence/QueryLogJpaEntity.java
@@ -40,9 +40,6 @@ public class QueryLogJpaEntity {
     @Column(nullable = false)
     private Long usedTokens;
 
-    @Column(nullable = false, precision = 19, scale = 4)
-    private BigDecimal cost;
-
     @Column(nullable = false)
     private LocalDateTime createAt;
 }

--- a/src/main/java/com/posicube/assignment/querylog/adapter/out/persistence/QueryLogMapper.java
+++ b/src/main/java/com/posicube/assignment/querylog/adapter/out/persistence/QueryLogMapper.java
@@ -16,7 +16,6 @@ public class QueryLogMapper {
                 .content(entity.getContent())
                 .answer(entity.getAnswer())
                 .usedTokens(entity.getUsedTokens())
-                .cost(entity.getCost())
                 .createAt(entity.getCreateAt())
                 .build();
     }
@@ -30,7 +29,6 @@ public class QueryLogMapper {
                 .content(domain.getContent())
                 .answer(domain.getAnswer())
                 .usedTokens(domain.getUsedTokens())
-                .cost(domain.getCost())
                 .createAt(domain.getCreateAt())
                 .build();
     }

--- a/src/main/java/com/posicube/assignment/querylog/adapter/out/persistence/QueryLogRepositoryImpl.java
+++ b/src/main/java/com/posicube/assignment/querylog/adapter/out/persistence/QueryLogRepositoryImpl.java
@@ -9,6 +9,9 @@ import com.posicube.assignment.users.exception.UserExceptionStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Repository
 @RequiredArgsConstructor
 public class QueryLogRepositoryImpl implements QueryLogRepository {
@@ -25,5 +28,17 @@ public class QueryLogRepositoryImpl implements QueryLogRepository {
 
         QueryLogJpaEntity savedEntity = jpaQueryLogRepository.save(entityToSave);
         return queryLogMapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public List<QueryLog> findAllByUserId(Long userId) {
+        UsersJpaEntity userEntity = jpaUserRepository.findUsersById(userId)
+                .orElseThrow(() -> new BaseException(UserExceptionStatus.USER_NOT_FOUND));
+
+        List<QueryLogJpaEntity> allByUser = jpaQueryLogRepository.findAllByUser(userEntity);
+
+        return allByUser.stream()
+                .map(queryLogMapper::toDomain)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/posicube/assignment/querylog/adapter/out/persistence/SpringDataJpaQueryLogRepository.java
+++ b/src/main/java/com/posicube/assignment/querylog/adapter/out/persistence/SpringDataJpaQueryLogRepository.java
@@ -1,6 +1,12 @@
 package com.posicube.assignment.querylog.adapter.out.persistence;
 
+import com.posicube.assignment.users.adapter.out.persistence.UsersJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface SpringDataJpaQueryLogRepository extends JpaRepository<QueryLogJpaEntity, Long> {
+    List<QueryLogJpaEntity> findAllByUser(UsersJpaEntity user);
+
+    UsersJpaEntity user(UsersJpaEntity user);
 }

--- a/src/main/java/com/posicube/assignment/querylog/domain/model/QueryLog.java
+++ b/src/main/java/com/posicube/assignment/querylog/domain/model/QueryLog.java
@@ -19,7 +19,6 @@ public class QueryLog {
     private final String content;
     private final String answer;
     private final Long usedTokens;
-    private final BigDecimal cost;
     private final LocalDateTime createAt;
 
     private static final int MAX_QUERY_LENGTH = 800;
@@ -28,21 +27,19 @@ public class QueryLog {
     //1. 생성 전용 메서드: Service 계층에서 새로운 QueryLog 만들때 사용
     public static QueryLog create(Users users, String q, ModelType type, String answer, Long usedTokens) {
         validationQueryLogInvariants(users, q, type, answer, usedTokens);
-        BigDecimal cost = calculateCost(usedTokens, type);
 
-        return new QueryLog(null, users.getId(), type, q.trim(), answer, usedTokens, cost, LocalDateTime.now());
+        return new QueryLog(null, users.getId(), type, q.trim(), answer, usedTokens, LocalDateTime.now());
     }
 
     //2. 재구성 전용 builder: JPA Entity -> Domain 변환 시 사용
     @Builder(builderMethodName = "fromPersistenceBuilder")
-    private QueryLog (Long id, Long userId, ModelType type, String content, String answer, Long usedTokens, BigDecimal cost, LocalDateTime createAt) {
+    private QueryLog (Long id, Long userId, ModelType type, String content, String answer, Long usedTokens, LocalDateTime createAt) {
         this.id = id;
         this.userId = userId;
         this.type = type;
         this.content = content;
         this.answer = answer;
         this.usedTokens = usedTokens;
-        this.cost = cost;
         this.createAt = createAt;
     }
 
@@ -54,14 +51,5 @@ public class QueryLog {
         if (Objects.isNull(answer)) throw new BaseException(QueryLogExceptionStatus.ANSWER_CANNOT_BE_NULL);
         if (Objects.isNull(usedTokens)) throw new BaseException(QueryLogExceptionStatus.USED_TOKEN_CANNOT_BE_NULL);
         if (q.trim().length() > MAX_QUERY_LENGTH) throw new BaseException(QueryLogExceptionStatus.QUERY_TOO_LONG);
-    }
-
-    private static BigDecimal calculateCost(long tokens, ModelType type) {
-        BigDecimal pricePer1KToken = type.getPricePer1KToken();
-        BigDecimal tokenBigDecimal = BigDecimal.valueOf(tokens);
-
-        BigDecimal costBefoeRounding = tokenBigDecimal.divide(THOUSAND, 10, RoundingMode.HALF_UP)
-                .multiply(pricePer1KToken);
-        return costBefoeRounding.setScale(2, RoundingMode.HALF_UP);
     }
 }

--- a/src/main/java/com/posicube/assignment/querylog/domain/model/QueryLog.java
+++ b/src/main/java/com/posicube/assignment/querylog/domain/model/QueryLog.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.Objects;
 

--- a/src/main/java/com/posicube/assignment/querylog/port/out/QueryLogRepository.java
+++ b/src/main/java/com/posicube/assignment/querylog/port/out/QueryLogRepository.java
@@ -2,6 +2,9 @@ package com.posicube.assignment.querylog.port.out;
 
 import com.posicube.assignment.querylog.domain.model.QueryLog;
 
+import java.util.List;
+
 public interface QueryLogRepository {
     QueryLog save(QueryLog queryLog);
+    List<QueryLog> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/posicube/assignment/users/adapter/in/web/UserController.java
+++ b/src/main/java/com/posicube/assignment/users/adapter/in/web/UserController.java
@@ -1,6 +1,7 @@
 package com.posicube.assignment.users.adapter.in.web;
 
 import com.posicube.assignment.common.baseResponse.BaseResponse;
+import com.posicube.assignment.users.application.commandquery.UsageResponse;
 import com.posicube.assignment.users.application.commandquery.UserCreateRequest;
 import com.posicube.assignment.users.application.commandquery.UserInfoResponse;
 import com.posicube.assignment.users.application.service.UsersService;
@@ -10,19 +11,23 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/users")
 @RequiredArgsConstructor
 public class UserController {
     private final UsersService usersService;
 
-    @PostMapping("")
+    @PostMapping("/users")
     public BaseResponse<UserInfoResponse> create(@Valid @RequestBody UserCreateRequest request) {
         Users user = usersService.createUser(request);
         return new BaseResponse<>(UserInfoResponse.from(user));
+    }
+
+    @PostMapping("/usage")
+    public BaseResponse<UsageResponse> getUsage(@RequestHeader("X-User-Id") Long userId) {
+        return new BaseResponse<>(usersService.getUserUsage(userId));
     }
 }

--- a/src/main/java/com/posicube/assignment/users/application/commandquery/UsageResponse.java
+++ b/src/main/java/com/posicube/assignment/users/application/commandquery/UsageResponse.java
@@ -1,0 +1,31 @@
+package com.posicube.assignment.users.application.commandquery;
+
+import com.posicube.assignment.users.domain.policy.ModelUsageDetails;
+import com.posicube.assignment.users.domain.policy.UsageSummary;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record UsageResponse (
+        String plan,
+        long quota,
+        long usedTokens,
+        long remainingTokens,
+        BigDecimal totalPrice,
+        List<ModelUsageDetails> models
+) {
+    public static UsageResponse from(UsageSummary summary) {
+        List<ModelUsageDetails> modelUsageDetailsList =
+                summary.modelUsageDetails().values().stream().collect(Collectors.toList());
+
+        return new UsageResponse(
+                summary.plan(),
+                summary.quota(),
+                summary.usedTokens(),
+                summary.remainingTokens(),
+                summary.totalPrice(),
+                modelUsageDetailsList
+        );
+    }
+}

--- a/src/main/java/com/posicube/assignment/users/application/service/UsersService.java
+++ b/src/main/java/com/posicube/assignment/users/application/service/UsersService.java
@@ -4,21 +4,27 @@ import com.posicube.assignment.common.exception.BaseException;
 import com.posicube.assignment.plan.application.service.PlanService;
 import com.posicube.assignment.plan.domain.model.Plan;
 import com.posicube.assignment.plan.domain.model.PlanType;
+import com.posicube.assignment.querylog.domain.model.QueryLog;
+import com.posicube.assignment.querylog.port.out.QueryLogRepository;
+import com.posicube.assignment.users.application.commandquery.UsageResponse;
 import com.posicube.assignment.users.domain.model.Users;
+import com.posicube.assignment.users.domain.policy.UsageCalculator;
+import com.posicube.assignment.users.domain.policy.UsageSummary;
 import com.posicube.assignment.users.port.UsersRepository;
 import com.posicube.assignment.users.exception.UserExceptionStatus;
 import com.posicube.assignment.users.application.commandquery.UserCreateRequest;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class UsersService {
     private final UsersRepository usersRepository;
     private final PlanService planService;
+    private final QueryLogRepository queryLogRepository;
 
     @Transactional
     public Users createUser(UserCreateRequest request) {
@@ -32,5 +38,18 @@ public class UsersService {
                 request.account(), request.password(), request.name(), plan);
 
         return usersRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public UsageResponse getUserUsage(Long userId) {
+        Users user = usersRepository.findUserById(userId)
+                .orElseThrow(() -> new BaseException(UserExceptionStatus.USER_NOT_FOUND));
+
+        List<QueryLog> queryLogs = queryLogRepository.findAllByUserId(userId);
+
+        UsageCalculator usageCalculator = new UsageCalculator();
+        UsageSummary usageSummary = usageCalculator.calculate(user, queryLogs);
+
+        return UsageResponse.from(usageSummary);
     }
 }

--- a/src/main/java/com/posicube/assignment/users/application/service/UsersService.java
+++ b/src/main/java/com/posicube/assignment/users/application/service/UsersService.java
@@ -25,6 +25,7 @@ public class UsersService {
     private final UsersRepository usersRepository;
     private final PlanService planService;
     private final QueryLogRepository queryLogRepository;
+    private final UsageCalculator usageCalculator;
 
     @Transactional
     public Users createUser(UserCreateRequest request) {
@@ -47,7 +48,6 @@ public class UsersService {
 
         List<QueryLog> queryLogs = queryLogRepository.findAllByUserId(userId);
 
-        UsageCalculator usageCalculator = new UsageCalculator();
         UsageSummary usageSummary = usageCalculator.calculate(user, queryLogs);
 
         return UsageResponse.from(usageSummary);

--- a/src/main/java/com/posicube/assignment/users/domain/policy/ModelUsageDetails.java
+++ b/src/main/java/com/posicube/assignment/users/domain/policy/ModelUsageDetails.java
@@ -1,0 +1,11 @@
+package com.posicube.assignment.users.domain.policy;
+
+import java.math.BigDecimal;
+
+public record ModelUsageDetails(
+        String name,
+        long tokens,
+        BigDecimal price
+) {
+
+}

--- a/src/main/java/com/posicube/assignment/users/domain/policy/UsageCalculator.java
+++ b/src/main/java/com/posicube/assignment/users/domain/policy/UsageCalculator.java
@@ -3,6 +3,7 @@ package com.posicube.assignment.users.domain.policy;
 import com.posicube.assignment.querylog.domain.model.ModelType;
 import com.posicube.assignment.querylog.domain.model.QueryLog;
 import com.posicube.assignment.users.domain.model.Users;
+import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -10,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Component
 public class UsageCalculator {
 
     private static final BigDecimal THOUSAND = new BigDecimal("1000");

--- a/src/main/java/com/posicube/assignment/users/domain/policy/UsageCalculator.java
+++ b/src/main/java/com/posicube/assignment/users/domain/policy/UsageCalculator.java
@@ -15,62 +15,130 @@ import java.util.stream.Collectors;
 public class UsageCalculator {
 
     private static final BigDecimal THOUSAND = new BigDecimal("1000");
+    private static final int PRICE_SCALE = 2;
 
+    /**
+     * 사용자의 전체 사용량 요약 정보를 계산합니다.
+     * 쿼리 로그 모델 타입별로 집계하여 총 토큰 사용량, 비용, 잔여 토큰을 계산합니다.
+     *
+     * @param user      사용자 정보
+     * @param queryLogs 쿼리 로그 목록
+     * @return 사용량 요약 정보 (플랜, 할당량, 사용 토큰, 잔여 토큰, 총 가격, 모델별 사용 내역)
+     */
     public UsageSummary calculate(Users user, List<QueryLog> queryLogs) {
-        long usedTokens = calculateUsedTokens(queryLogs);
-        long quota = user.getTokens().getQuota();
-        long remainingToken = calculateRemainingTokens(quota, usedTokens);
         Map<ModelType, ModelUsageDetails> modelUsageDetailsMap = calculateModelUsageDetails(queryLogs);
-        BigDecimal totalPrice = calculateTotalPrice(modelUsageDetailsMap);
+
+        long totalTokens = sumTotalTokens(modelUsageDetailsMap);
+        BigDecimal totalPrice = sumTotalPrice(modelUsageDetailsMap);
+
+        long quota = user.getTokens().getQuota();
+        long remainingToken = calculateRemainingTokens(quota, totalTokens);
 
         return new UsageSummary(
                 user.getPlanType().name(),
                 quota,
-                usedTokens,
+                totalTokens,
                 remainingToken,
                 totalPrice,
                 modelUsageDetailsMap
         );
     }
 
-    private long calculateUsedTokens(List<QueryLog> queryLogs) {
-        return queryLogs.stream()
-                .mapToLong(QueryLog::getUsedTokens)
-                .sum();
-    }
-
-    private long calculateRemainingTokens(long quota, long usedTokens) {
-        long remaining = quota - usedTokens;
-        return Math.max(remaining, 0);
-    }
-
+    /**
+     * 쿼리 로그를 모델 타입별로 그룹화하여 각 모델의 사용 내역을 계산합니다.
+     * 동일한 모델 타입의 로그들을 하나의 ModelUsageDetails로 집계합니다.
+     *
+     * @param queryLogs 쿼리 로그 목록
+     * @return 모델 타입별 사용 내역 맵
+     */
     private Map<ModelType, ModelUsageDetails> calculateModelUsageDetails(List<QueryLog> queryLogs) {
         return queryLogs.stream()
                 .collect(Collectors.groupingBy(
                         QueryLog::getType,
-                        Collectors.collectingAndThen(Collectors.toList(), this::createModelUsageDetails)
+                        Collectors.collectingAndThen(
+                                Collectors.toList(),
+                                this::createModelUsageDetails)
                 ));
     }
 
+    /**
+     * 동일한 모델 타입의 쿼리 로그들로부터 모델 사용 내역을 생성합니다.
+     * 총 토큰 수를 합산하고 해당 모델 가격 정책에 따라 비용을 계산합니다.
+     *
+     * @param logs 동일 모델 타입의 쿼리 로그 목록
+     * @return 모델 사용 내역(모델명, 총 토큰 수, 가격)
+     */
     private ModelUsageDetails createModelUsageDetails(List<QueryLog> logs) {
         ModelType type = logs.get(0).getType();
-        long totalModelTokens = calculateUsedTokens(logs);
-        BigDecimal modelPrice = calculatePrice(type, totalModelTokens);
-        return new ModelUsageDetails(type.getName(), totalModelTokens, modelPrice);
+        long totalTokens = sumTokens(logs);
+        BigDecimal price = calculatePrice(type, totalTokens);
+
+        return new ModelUsageDetails(type.getName(), totalTokens, price);
     }
 
-    private BigDecimal calculatePrice(ModelType modelType, long totalTokens) {
-        BigDecimal pricePer1KToken = modelType.getPricePer1KToken();
-        BigDecimal tokenBigDecimal = BigDecimal.valueOf(totalTokens);
-        return tokenBigDecimal.divide(THOUSAND, 10, RoundingMode.HALF_UP)
-                .multiply(pricePer1KToken)
-                .setScale(2, RoundingMode.HALF_UP);
+    /**
+     * 쿼리 로그 목록의 총 토큰 수를 합산합니다.
+     *
+     * @param logs 쿼리 로그 목록
+     * @return 총 사용 토큰 수
+     */
+    private long sumTokens(List<QueryLog> logs) {
+        return logs.stream()
+                .mapToLong(QueryLog::getUsedTokens)
+                .sum();
     }
 
-    private BigDecimal calculateTotalPrice(Map<ModelType, ModelUsageDetails> modelUsageDetails) {
-        return modelUsageDetails.values().stream()
+    /**
+     * 모델별 사용 내역에서 전체 토큰 수를 합산합니다.
+     *
+     * @param modelUsageDetailsMap 모델 타입별 사용 내역 맵
+     * @return 전체 사용 토큰 수
+     */
+    private long sumTotalTokens(Map<ModelType, ModelUsageDetails> modelUsageDetailsMap) {
+        return modelUsageDetailsMap.values().stream()
+                .mapToLong(ModelUsageDetails::tokens)
+                .sum();
+    }
+
+    /**
+     * 모델별 사용 내역에서 전체 가격을 합산합니다.
+     * 합산 후 소수점 2자리에서 반올림 합니다.
+     *
+     * @param modelUsageDetailsMap 모델 타입별 사용 내역 맵
+     * @return 총 사용 금액(소수점 2자리)
+     */
+    private BigDecimal sumTotalPrice(Map<ModelType, ModelUsageDetails> modelUsageDetailsMap) {
+        return modelUsageDetailsMap.values().stream()
                 .map(ModelUsageDetails::price)
                 .reduce(BigDecimal.ZERO, BigDecimal::add)
-                .setScale(2, RoundingMode.HALF_UP);
+                .setScale(PRICE_SCALE, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * 잔여 토큰 수를 계산합니다.
+     * 계산 공식: 할당량 - 사용량 (결과가 음수인 경우 0 반환)
+     *
+     * @param quota      할당된 토큰 수
+     * @param usedTokens 사용한 토큰 수
+     * @return 잔여 토큰 수
+     */
+    private long calculateRemainingTokens(long quota, long usedTokens) {
+        return Math.max(quota - usedTokens, 0);
+    }
+
+    /**
+     * 특정 모델의 사용 토큰에 대한 가격을 계산합니다.
+     * 계산 공식: (총 토큰 수 / 1000) * 모델의 1K당 가격
+     * 중간 계산은 소수점 10자리, 최종 결과는 소수점 2자리에서 반올림합니다.
+     *
+     * @param type        모델 타입
+     * @param totalTokens 총 토큰 수
+     * @return 계산된 가격(소수점 2자리)
+     */
+    private BigDecimal calculatePrice(ModelType type, long totalTokens) {
+        return BigDecimal.valueOf(totalTokens)
+                .divide(THOUSAND, 10, RoundingMode.HALF_UP)
+                .multiply(type.getPricePer1KToken())
+                .setScale(PRICE_SCALE, RoundingMode.HALF_UP);
     }
 }

--- a/src/main/java/com/posicube/assignment/users/domain/policy/UsageCalculator.java
+++ b/src/main/java/com/posicube/assignment/users/domain/policy/UsageCalculator.java
@@ -1,0 +1,74 @@
+package com.posicube.assignment.users.domain.policy;
+
+import com.posicube.assignment.querylog.domain.model.ModelType;
+import com.posicube.assignment.querylog.domain.model.QueryLog;
+import com.posicube.assignment.users.domain.model.Users;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class UsageCalculator {
+
+    private static final BigDecimal THOUSAND = new BigDecimal("1000");
+
+    public UsageSummary calculate(Users user, List<QueryLog> queryLogs) {
+        long usedTokens = calculateUsedTokens(queryLogs);
+        long quota = user.getTokens().getQuota();
+        long remainingToken = calculateRemainingTokens(quota, usedTokens);
+        Map<ModelType, ModelUsageDetails> modelUsageDetailsMap = calculateModelUsageDetails(queryLogs);
+        BigDecimal totalPrice = calculateTotalPrice(modelUsageDetailsMap);
+
+        return new UsageSummary(
+                user.getPlanType().name(),
+                quota,
+                usedTokens,
+                remainingToken,
+                totalPrice,
+                modelUsageDetailsMap
+        );
+    }
+
+    private long calculateUsedTokens(List<QueryLog> queryLogs) {
+        return queryLogs.stream()
+                .mapToLong(QueryLog::getUsedTokens)
+                .sum();
+    }
+
+    private long calculateRemainingTokens(long quota, long usedTokens) {
+        long remaining = quota - usedTokens;
+        return Math.max(remaining, 0);
+    }
+
+    private Map<ModelType, ModelUsageDetails> calculateModelUsageDetails(List<QueryLog> queryLogs) {
+        return queryLogs.stream()
+                .collect(Collectors.groupingBy(
+                        QueryLog::getType,
+                        Collectors.collectingAndThen(Collectors.toList(), this::createModelUsageDetails)
+                ));
+    }
+
+    private ModelUsageDetails createModelUsageDetails(List<QueryLog> logs) {
+        ModelType type = logs.get(0).getType();
+        long totalModelTokens = calculateUsedTokens(logs);
+        BigDecimal modelPrice = calculatePrice(type, totalModelTokens);
+        return new ModelUsageDetails(type.getName(), totalModelTokens, modelPrice);
+    }
+
+    private BigDecimal calculatePrice(ModelType modelType, long totalTokens) {
+        BigDecimal pricePer1KToken = modelType.getPricePer1KToken();
+        BigDecimal tokenBigDecimal = BigDecimal.valueOf(totalTokens);
+        return tokenBigDecimal.divide(THOUSAND, 10, RoundingMode.HALF_UP)
+                .multiply(pricePer1KToken)
+                .setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal calculateTotalPrice(Map<ModelType, ModelUsageDetails> modelUsageDetails) {
+        return modelUsageDetails.values().stream()
+                .map(ModelUsageDetails::price)
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .setScale(2, RoundingMode.HALF_UP);
+    }
+}

--- a/src/main/java/com/posicube/assignment/users/domain/policy/UsageSummary.java
+++ b/src/main/java/com/posicube/assignment/users/domain/policy/UsageSummary.java
@@ -1,0 +1,16 @@
+package com.posicube.assignment.users.domain.policy;
+
+import com.posicube.assignment.querylog.domain.model.ModelType;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public record UsageSummary(
+        String plan,
+        long quota,
+        long usedTokens,
+        long remainingTokens,
+        BigDecimal totalPrice,
+        Map<ModelType, ModelUsageDetails> modelUsageDetails
+) {
+}

--- a/src/test/java/com/posicube/assignment/domain/querylog/QueryLogTest.java
+++ b/src/test/java/com/posicube/assignment/domain/querylog/QueryLogTest.java
@@ -54,7 +54,6 @@ public class QueryLogTest {
         assertThat(queryLog.getType()).isEqualTo(ModelType.GPT5);
         assertThat(queryLog.getContent()).isEqualTo(prompt);
         assertThat(queryLog.getUsedTokens()).isEqualTo(expectedTokens);
-        assertThat(queryLog.getCost()).isEqualTo(expectedCost);
         assertThat(queryLog.getAnswer()).isEqualTo(answer);
     }
 
@@ -82,7 +81,6 @@ public class QueryLogTest {
         assertThat(queryLog.getType()).isEqualTo(ModelType.GPT_4O_MINI);
         assertThat(queryLog.getContent()).isEqualTo(prompt);
         assertThat(queryLog.getUsedTokens()).isEqualTo(expectedTokens);
-        assertThat(queryLog.getCost()).isEqualTo(expectedCost);
         assertThat(queryLog.getAnswer()).isEqualTo(answer);
     }
 


### PR DESCRIPTION
## 🚀 개요
사용자 ID(`X-User-Id`)를 기반으로 해당 사용자의 요금제 정보, 누적 토큰 사용량, 잔여 토큰, 총 발생 비용 및 모델별 상세 사용  내역을 조회하는 API를 구현했습니다. `POST /users/usage` 엔드포인트를 통해 사용량 조회가 가능합니다.

## 🛠️ 주요 작업 내용
-  사용자 사용량 조회 API 추가
   - `UserController`에 `/users/usage` 엔드포인트를 추가하여 `X-User-Id` 헤더로 사용자 사용량 조회를 처리합니다.
- 사용량 계산 로직 리팩토링 
  - `UsersService`에 `getUserUsage` 메서드를 추가하여 사용량 조회 비즈니스 로직을 오케스트레이션합니다.
  - `UsageCalculator`를 `users` 도메인 정책으로 추가하여, 모델별 토큰 사용량 집계 및 비용 계산을 담당하도록 했습니다.
  - `UsageSummary`, `ModelUsageDetails` 등 계산 결과를 담는 도메인 객체를 추가하여 계층 간 데이터 전송을 명확히 했습니다.                                                                                                                    - QueryLog 도메인 및 리포지토리 수정
  - `QueryLog` 도메인에서 `cost` 필드 및 관련 계산 로직을 제거하여, 사용량 계산 책임을 `UsageCalculator`로 완전히 이전했습니다. 이로써 정밀도 손실 및 반올림 오류를 해결했습니다.
  - `QueryLogRepository`에 `findAllByUserId` 메서드를 추가하여 특정 사용자의 모든 쿼리 로그를 효율적으로 조회할 수 있도록 했습니다.  

## 🔗 관련 이슈
Resolves: #21 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention](https://www.notion.so/Git-1a10cae5674e813f8c60ebb4a8f99ca4?pvs=4#1aa0cae5674e807aa012d921c8fa6fe4) 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
