### PR TITLE
fix: 유저 생성 시 중복 생성 오류 해결

### DIFF
--- a/src/main/java/com/posicube/assignment/users/adapter/out/persistence/SpringDataJpaUsersRepository.java
+++ b/src/main/java/com/posicube/assignment/users/adapter/out/persistence/SpringDataJpaUsersRepository.java
@@ -1,7 +1,6 @@
 package com.posicube.assignment.users.adapter.out.persistence;
 
 import com.posicube.assignment.users.application.commandquery.UserInfoResponse;
-import com.posicube.assignment.users.domain.model.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/posicube/assignment/users/adapter/out/persistence/SpringDataJpaUsersRepository.java
+++ b/src/main/java/com/posicube/assignment/users/adapter/out/persistence/SpringDataJpaUsersRepository.java
@@ -1,6 +1,7 @@
 package com.posicube.assignment.users.adapter.out.persistence;
 
 import com.posicube.assignment.users.application.commandquery.UserInfoResponse;
+import com.posicube.assignment.users.domain.model.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -11,6 +12,9 @@ import java.util.Optional;
 public interface SpringDataJpaUsersRepository extends JpaRepository<UsersJpaEntity, Long> {
 
     Optional<UsersJpaEntity> findUsersById(Long id);
+
+    Optional<UsersJpaEntity> findUsersByAccount(String account);
+
 
     @Modifying
     @Query("UPDATE UsersJpaEntity u SET u.usedTokens = 0, u.remainingTokens = u.quota")

--- a/src/main/java/com/posicube/assignment/users/adapter/out/persistence/UsersJpaEntity.java
+++ b/src/main/java/com/posicube/assignment/users/adapter/out/persistence/UsersJpaEntity.java
@@ -20,7 +20,7 @@ public class UsersJpaEntity {
             foreignKey = @ForeignKey(name = "FK_USER_PLAN"))
     private PlanJpaEntity plan;
 
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, length = 100, unique = true)
     private String account;
 
     @Column(nullable = false, length = 100)

--- a/src/main/java/com/posicube/assignment/users/adapter/out/persistence/UsersRepositoryImpl.java
+++ b/src/main/java/com/posicube/assignment/users/adapter/out/persistence/UsersRepositoryImpl.java
@@ -44,4 +44,10 @@ public class UsersRepositoryImpl implements UsersRepository {
     public List<UserInfoResponse> findAllUsersInfo() {
         return jpaUsersRepository.findAllUsersInfo();
     }
+
+    @Override
+    public Optional<Users> findUsersByAccount(String account) {
+        return jpaUsersRepository.findUsersByAccount(account)
+                .map(mapper::toDomain);
+    }
 }

--- a/src/main/java/com/posicube/assignment/users/application/service/UsersService.java
+++ b/src/main/java/com/posicube/assignment/users/application/service/UsersService.java
@@ -7,13 +7,13 @@ import com.posicube.assignment.plan.domain.model.PlanType;
 import com.posicube.assignment.querylog.domain.model.QueryLog;
 import com.posicube.assignment.querylog.port.out.QueryLogRepository;
 import com.posicube.assignment.users.application.commandquery.UsageResponse;
+import com.posicube.assignment.users.application.commandquery.UserCreateRequest;
 import com.posicube.assignment.users.application.commandquery.UserInfoResponse;
 import com.posicube.assignment.users.domain.model.Users;
 import com.posicube.assignment.users.domain.policy.UsageCalculator;
 import com.posicube.assignment.users.domain.policy.UsageSummary;
-import com.posicube.assignment.users.port.UsersRepository;
 import com.posicube.assignment.users.exception.UserExceptionStatus;
-import com.posicube.assignment.users.application.commandquery.UserCreateRequest;
+import com.posicube.assignment.users.port.UsersRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,12 +24,17 @@ import java.util.List;
 @RequiredArgsConstructor
 public class UsersService {
     private final UsersRepository usersRepository;
-    private final PlanService planService;
     private final QueryLogRepository queryLogRepository;
+    private final PlanService planService;
     private final UsageCalculator usageCalculator;
 
     @Transactional
     public Users createUser(UserCreateRequest request) {
+        //1. 기존 사용자인지 확인한다.
+        usersRepository.findUsersByAccount(request.account()).ifPresent(user -> {
+            throw new BaseException(UserExceptionStatus.DUPLICATE_ACCOUNT);
+        });
+
         //1. plan을 찾는다.
         PlanType type = PlanType.from(request.plan());
         Plan plan = planService.findPlanByType(type)

--- a/src/main/java/com/posicube/assignment/users/application/service/UsersService.java
+++ b/src/main/java/com/posicube/assignment/users/application/service/UsersService.java
@@ -35,12 +35,12 @@ public class UsersService {
             throw new BaseException(UserExceptionStatus.DUPLICATE_ACCOUNT);
         });
 
-        //1. plan을 찾는다.
+        //2. plan을 찾는다.
         PlanType type = PlanType.from(request.plan());
         Plan plan = planService.findPlanByType(type)
                 .orElseThrow(() -> new BaseException(UserExceptionStatus.INVALID_PLAN_FOR_USER_CREATION));
 
-        //2. 해당 plan을 갖는 user를 만든다.
+        //3. 해당 plan을 갖는 user를 만든다.
         Users user = Users.create(
                 request.account(), request.password(), request.name(), plan);
 

--- a/src/main/java/com/posicube/assignment/users/exception/UserExceptionStatus.java
+++ b/src/main/java/com/posicube/assignment/users/exception/UserExceptionStatus.java
@@ -17,6 +17,7 @@ public enum UserExceptionStatus implements ResponseStatus {
     TOKEN_CANNOT_NULL(false, "User-7", "tokens는 null일 수 없습니다."),
     INVALID_PLAN_FOR_USER_CREATION(false, "User-8", "사용자 생성에 유효하지 않은 요금제입니다."),
     USER_NOT_FOUND(false, "User-9", "사용자를 찾을 수 없습니다."),
+    DUPLICATE_ACCOUNT(false, "User-10", "이미 존재하는 계정입니다."),
     ;
 
     private final boolean isSuccess;

--- a/src/main/java/com/posicube/assignment/users/port/UsersRepository.java
+++ b/src/main/java/com/posicube/assignment/users/port/UsersRepository.java
@@ -11,4 +11,5 @@ public interface UsersRepository {
     Optional<Users> findUserById(Long id);
     int resetAllUserTokens();
     List<UserInfoResponse> findAllUsersInfo();
+    Optional<Users> findUsersByAccount(String account);
 }

--- a/src/test/java/com/posicube/assignment/domain/plan/PlanTest.java
+++ b/src/test/java/com/posicube/assignment/domain/plan/PlanTest.java
@@ -15,7 +15,7 @@ public class PlanTest {
     private Plan plan;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         //given
         PlanType lite = PlanType.LITE;
 
@@ -25,7 +25,7 @@ public class PlanTest {
 
     @Test
     @DisplayName("생성 성공: 정상 생성")
-    public void create_plan_success() throws Exception {
+    public void create_plan_success() {
         //given
         PlanType lite = PlanType.LITE;
 
@@ -38,7 +38,7 @@ public class PlanTest {
 
     @Test
     @DisplayName("생성 실패: PlanType이 null이면 예외 반환")
-    public void create_plan_fail() throws Exception {
+    public void create_plan_fail() {
         //when&then
         assertThatThrownBy(() -> Plan.create(null))
                 .isInstanceOf(BaseException.class)
@@ -47,7 +47,7 @@ public class PlanTest {
 
     @Test
     @DisplayName("changePlanType 메서드 성공: PlanType 변경 성공")
-    public void change_plan_type_success() throws Exception {
+    public void change_plan_type_success() {
         //when&then
         plan.changePlanType(PlanType.PRO);
         assertThat(plan.getType()).isEqualTo(PlanType.PRO);
@@ -58,7 +58,7 @@ public class PlanTest {
 
     @Test
     @DisplayName("changePlanType 메서드 실패: PlanType이 같거나 null이면 예외 발생")
-    public void update_plan_success() throws Exception {
+    public void update_plan_success() {
         //when&then
         assertThatThrownBy(() -> plan.changePlanType(PlanType.LITE))
                 .isInstanceOf(BaseException.class)

--- a/src/test/java/com/posicube/assignment/domain/querylog/QueryLogServiceTest.java
+++ b/src/test/java/com/posicube/assignment/domain/querylog/QueryLogServiceTest.java
@@ -35,13 +35,19 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class QueryLogServiceTest {
-    @Mock UsersRepository usersRepository;
-    @Mock QueryLogRepository queryLogRepository;
-    @Mock LlmClient llmClient;
-    @Mock RateLimiter rateLimiter;
-    @Mock TokenCalculator tokenCalculator;
+    @Mock
+    UsersRepository usersRepository;
+    @Mock
+    QueryLogRepository queryLogRepository;
+    @Mock
+    LlmClient llmClient;
+    @Mock
+    RateLimiter rateLimiter;
+    @Mock
+    TokenCalculator tokenCalculator;
 
-    @InjectMocks QueryLogService queryService;
+    @InjectMocks
+    QueryLogService queryService;
 
     private Users mockUser;
     private QueryRequest mockRequest;
@@ -54,7 +60,7 @@ public class QueryLogServiceTest {
 
     @Test
     @DisplayName("submitQuery: 사용자 조회 실패: 존재하지 않는 사용자면 예외를 던진다.")
-    public void submitQuery_userNotFound_fail() throws Exception {
+    public void submitQuery_userNotFound_fail() {
         //given: ID조회 시 결과 없음
         when(usersRepository.findUserById(anyLong())).thenReturn(Optional.empty());
 
@@ -66,7 +72,7 @@ public class QueryLogServiceTest {
 
     @Test
     @DisplayName("submitQuery: Rate Limit를 초과하면 예외를 던진다.")
-    public void submitQuery_rateLimit_fail() throws Exception {
+    public void submitQuery_rateLimit_fail() {
         //given: RateLimiter가 항상 요청 거부
         when(usersRepository.findUserById(1L)).thenReturn(Optional.of(mockUser));
         when(rateLimiter.isAllowed(1L)).thenReturn(false);
@@ -79,7 +85,7 @@ public class QueryLogServiceTest {
 
     @Test
     @DisplayName("submitQuery: 잔여 토큰이 없으면 예외를 던진다.")
-    public void submitQuery_insufficientTokens_fail() throws Exception {
+    public void submitQuery_insufficientTokens_fail() {
         //given: 토큰이 0인 mock Token 객체 주입
         Tokens zeroToken = mock(Tokens.class);
         when(zeroToken.getRemainingTokens()).thenReturn(0L);
@@ -96,7 +102,7 @@ public class QueryLogServiceTest {
 
     @Test
     @DisplayName("정상 요청 시 LlmClient에서 응답")
-    public void submitQuery_llmClientResponse_success() throws Exception {
+    public void submitQuery_llmClientResponse_success() {
         //given: 모든 의존성이 정상적으로 동작하도록 설정
         when(usersRepository.findUserById(1L)).thenReturn(Optional.of(mockUser));
         when(rateLimiter.isAllowed(1L)).thenReturn(true);
@@ -114,7 +120,7 @@ public class QueryLogServiceTest {
 
     @Test
     @DisplayName("정상 요청 시 토큰을 정확히 차감한다.")
-    public void submitQuery_deDuctTokens_success() throws Exception {
+    public void submitQuery_deDuctTokens_success() {
         //given: 실제 Users(spy) 객체와 그 안의 실제 Tokens 객체 사용
         long initialRemainingTokens = mockUser.getTokens().getRemainingTokens();
         long expectedUsedTokens = new TokenCalculator().calculateTokensFromPrompt(mockRequest.q());
@@ -138,7 +144,7 @@ public class QueryLogServiceTest {
 
     @Test
     @DisplayName("잔여 토큰보다 큰 요청도 마지막이라면 성공한다.")
-    public void submitQuery_lastRequest_succeeds() throws Exception {
+    public void submitQuery_lastRequest_succeeds() {
         //given: 잔여 토큰이 매우 적은 상황 설정
         Tokens realTokens = new Tokens(10000L, 9995L, 5L);
         Users realUser = Users.fromPersistenceBuilder()
@@ -175,7 +181,7 @@ public class QueryLogServiceTest {
 
     @Test
     @DisplayName("LLM 클라이언트 호출 실패 시 예외 발생 및 토큰 미차감")
-    public void submitQuery_llmClient_fail() throws Exception {
+    public void submitQuery_llmClient_fail() {
         //given: LLM 클라이언트 호출 시 예외 발생 설정
         when(usersRepository.findUserById(1L)).thenReturn(Optional.of(mockUser));
         when(rateLimiter.isAllowed(1L)).thenReturn(true);

--- a/src/test/java/com/posicube/assignment/domain/querylog/QueryLogTest.java
+++ b/src/test/java/com/posicube/assignment/domain/querylog/QueryLogTest.java
@@ -32,7 +32,7 @@ public class QueryLogTest {
 
     @Test
     @DisplayName("성공: GPT-5 모델의 토큰과 비용을 정확히 계산한다.")
-    public void createQuery_withGpt5_calculatesTokensAndCostCorrectly() throws Exception {
+    public void createQuery_withGpt5_calculatesTokensAndCostCorrectly() {
         //given
         String prompt = "안녕하세요? 이번 포지큐브 백엔드 주니어 개발자에 지원하게 된 송재명 입니다. 100자에 맞춰 프롬프트를 작성하면 GPT-5모델은 5L의 토큰과 0.02의 비용이 청구될 것입니다.";
         String answer = "GPT-5 모델의 답변입니다.";
@@ -59,7 +59,7 @@ public class QueryLogTest {
 
     @Test
     @DisplayName("성공: GPT-4o-mini 모델의 토큰과 비용을 정확히 계산한다.")
-    public void createQuery_withGpt4iMini_calculatesTokensAndCostCorrectly() throws Exception {
+    public void createQuery_withGpt4iMini_calculatesTokensAndCostCorrectly() {
         //given
         String prompt = "안녕하세요? 이번 포지큐브 백엔드 주니어 개발자에 지원하게 된 송재명 입니다. 100자에 맞춰 프롬프트를 작성하면 GPT-4모델은 5L의 토큰과 0.02의 비용이 청구될 것입니다.";
         String answer = "GPT-4o-mini 모델의 답변입니다.";
@@ -86,7 +86,7 @@ public class QueryLogTest {
 
     @Test
     @DisplayName("성공: 토큰 계산 시 소수접을 정확히 반올림 한다.")
-    public void createQueryLog_roundsTokensCorrectly() throws Exception {
+    public void createQueryLog_roundsTokensCorrectly() {
         //given
         String promptRoundingUpFromHalf = "Length 999";  //10자 -> 10 * 0.75 = 7.5 -> 8
         String promptRoundingDownFromQuarter = "Length 1000"; //11자 -> 11 * 0.75 = 8.25 -> 8
@@ -108,7 +108,7 @@ public class QueryLogTest {
 
     @Test
     @DisplayName("실패: User가 null이면 예외를 발생시킨다.")
-    public void createQueryLog_withNullUser_fail() throws Exception {
+    public void createQueryLog_withNullUser_fail() {
         //given
         String prompt = "User가 null이면 예외를 발생시킨다.";
         String answer = "답변입니다.";
@@ -122,14 +122,14 @@ public class QueryLogTest {
 
     @Test
     @DisplayName("실패: 질의 내용(q)이 null 이거나 비어 있으면 예외를 발생시킨다.")
-    public void createQueryLog_withNullBlankQuery_fail() throws Exception {
+    public void createQueryLog_withNullBlankQuery_fail() {
         //given
         String prompt = " ";
         String answer = "답변입니다.";
         Long usedTokens = tokenCalculator.calculateTokensFromPrompt(prompt);
 
         //when&then
-        assertThatThrownBy(() -> QueryLog.create(testUser, null, ModelType.GPT5, answer,null))
+        assertThatThrownBy(() -> QueryLog.create(testUser, null, ModelType.GPT5, answer, null))
                 .isInstanceOf(BaseException.class)
                 .hasMessage(QueryLogExceptionStatus.QUERY_CANNOT_BE_NULL.getMessage());
 
@@ -140,7 +140,7 @@ public class QueryLogTest {
 
     @Test
     @DisplayName("실패: ModelType이 null 이거나 없는 모델이 들어오면 예외를 발생시킨다.")
-    public void createQueryLog_withNullModelType_fail() throws Exception {
+    public void createQueryLog_withNullModelType_fail() {
         //given
         String prompt = "ModelType이 null 이면 예외를 발생시킨다.";
         String answer = "답변입니다.";
@@ -154,20 +154,20 @@ public class QueryLogTest {
 
     @Test
     @DisplayName("실패: usedTokens이 null이면 예외를 발생시킨다.")
-    public void createQuery_withNullUsedTokens_fail() throws Exception {
+    public void createQuery_withNullUsedTokens_fail() {
         //given
         String prompt = "usedToken이 null이면 예외를 발생시킨다.";
         String answer = "답변입니다.";
 
         //when&then
-        assertThatThrownBy(() -> QueryLog.create(testUser, prompt, ModelType.GPT5,  answer,null))
+        assertThatThrownBy(() -> QueryLog.create(testUser, prompt, ModelType.GPT5, answer, null))
                 .isInstanceOf(BaseException.class)
                 .hasMessage(QueryLogExceptionStatus.USED_TOKEN_CANNOT_BE_NULL.getMessage());
     }
 
     @Test
     @DisplayName("실패: 질의 내용(q)이 800자를 초과하면 예외를 발생시킨다.")
-    public void createQuery_withTooLongQuery_fail() throws Exception {
+    public void createQuery_withTooLongQuery_fail() {
         //given
         String longPrompt = "글".repeat(801);
         String answer = "답변입니다.";

--- a/src/test/java/com/posicube/assignment/domain/users/TokenResetSchedulerTest.java
+++ b/src/test/java/com/posicube/assignment/domain/users/TokenResetSchedulerTest.java
@@ -19,8 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 @Transactional
 public class TokenResetSchedulerTest {
-    @Autowired private TokenResetScheduler tokenResetScheduler;
-    @Autowired private UsersService usersService;
+    @Autowired
+    private TokenResetScheduler tokenResetScheduler;
+    @Autowired
+    private UsersService usersService;
 
     @BeforeEach
     void setUp() {
@@ -30,7 +32,7 @@ public class TokenResetSchedulerTest {
 
     @Test
     @DisplayName("모든 사용자의 토큰 사용량을 성공적으로 초기화 한다.")
-    public void resetAllUsersTokens_shouldReset() throws Exception {
+    public void resetAllUsersTokens_shouldReset() {
         //given
         tokenResetScheduler.resetAllUserTokens();
 

--- a/src/test/java/com/posicube/assignment/domain/users/UsersServiceTest.java
+++ b/src/test/java/com/posicube/assignment/domain/users/UsersServiceTest.java
@@ -1,11 +1,13 @@
 package com.posicube.assignment.domain.users;
 
+import com.posicube.assignment.common.exception.BaseException;
 import com.posicube.assignment.plan.application.service.PlanService;
 import com.posicube.assignment.plan.domain.model.Plan;
 import com.posicube.assignment.plan.domain.model.PlanType;
 import com.posicube.assignment.users.application.commandquery.UserCreateRequest;
 import com.posicube.assignment.users.application.service.UsersService;
 import com.posicube.assignment.users.domain.model.Users;
+import com.posicube.assignment.users.exception.UserExceptionStatus;
 import com.posicube.assignment.users.port.UsersRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -56,5 +59,22 @@ public class UsersServiceTest {
 
         assertThat(savedUser.getAccount()).isEqualTo("hysic88");
         assertThat(savedUser.getPassword()).isEqualTo("123456");
+    }
+
+    @Test
+    @DisplayName("유저 생성 실패: 이미 계정이 존재할 경우 예외를 반환한다.")
+    public void createUser_fail() throws Exception {
+        //given
+        UserCreateRequest request = new UserCreateRequest("hysic88", "123456", "현식", "LITE");
+        when(usersRepository.findUsersByAccount(request.account())).thenReturn(Optional.of(mock(Users.class)));
+
+        //when&then
+        assertThatThrownBy(() -> usersService.createUser(request))
+                .isInstanceOf(BaseException.class)
+                .hasMessage(UserExceptionStatus.DUPLICATE_ACCOUNT.getMessage());
+
+        //then
+        verify(usersRepository, never()).save(any(Users.class));
+
     }
 }

--- a/src/test/java/com/posicube/assignment/domain/users/UsersServiceTest.java
+++ b/src/test/java/com/posicube/assignment/domain/users/UsersServiceTest.java
@@ -25,13 +25,16 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class UsersServiceTest {
-    @Mock private UsersRepository usersRepository;
-    @Mock private PlanService planService;
-    @InjectMocks private UsersService usersService;
+    @Mock
+    private UsersRepository usersRepository;
+    @Mock
+    private PlanService planService;
+    @InjectMocks
+    private UsersService usersService;
 
     @Test
     @DisplayName("createUser: 새로운 사용자를 성공적으로 생성하고 저장한다.")
-    public void createUser() throws Exception {
+    public void createUser() {
         //given
         UserCreateRequest request = new UserCreateRequest("hysic88", "123456", "현식", "LITE");
         Plan plan = Plan.create(PlanType.LITE);
@@ -63,7 +66,7 @@ public class UsersServiceTest {
 
     @Test
     @DisplayName("유저 생성 실패: 이미 계정이 존재할 경우 예외를 반환한다.")
-    public void createUser_fail() throws Exception {
+    public void createUser_fail() {
         //given
         UserCreateRequest request = new UserCreateRequest("hysic88", "123456", "현식", "LITE");
         when(usersRepository.findUsersByAccount(request.account())).thenReturn(Optional.of(mock(Users.class)));

--- a/src/test/java/com/posicube/assignment/domain/users/UsersTest.java
+++ b/src/test/java/com/posicube/assignment/domain/users/UsersTest.java
@@ -26,7 +26,7 @@ public class UsersTest {
 
     @Test
     @DisplayName("생성 성공: User 정상 생성")
-    public void create_user_success() throws Exception {
+    public void create_user_success() {
         //then
         assertThat(user.getAccount()).isEqualTo("evanbackeng@gmail.com");
         assertThat(user.getPassword()).isEqualTo("pass1234");
@@ -38,7 +38,7 @@ public class UsersTest {
 
     @Test
     @DisplayName("생성 실패: User account, password, name이 null이면 예외 발생")
-    public void create_user_account_password_name_cannot_null_fail() throws Exception {
+    public void create_user_account_password_name_cannot_null_fail() {
         //when&then
         assertThatThrownBy(() -> Users.create(
                 null, "pass1234", "evan", Plan.create(PlanType.LITE)))
@@ -58,7 +58,7 @@ public class UsersTest {
 
     @Test
     @DisplayName("생성 실패: User account, password, name이 공백이 포함되면 예외 발생")
-    public void create_user_account_password_name_cannot_white_space_fail() throws Exception {
+    public void create_user_account_password_name_cannot_white_space_fail() {
         //when&then
         assertThatThrownBy(() -> Users.create(
                 "ev an  backeng@  gmail.    com", "pass1234", "evan", Plan.create(PlanType.LITE)))


### PR DESCRIPTION
## 🚀 개요
  사용자 생성 시 중복된 계정이 생성되는 것을 방지하기 위한 기능을 추가했습니다. 애플리케이션 레벨에서 선제적으로 중복을 확인하여 
  명확한 에러 메시지를 제공하고, 데이터베이스 레벨에서도 고유 제약 조건을 추가하여 데이터 무결성을 보장하는 이중 안전장치를 
  마련했습니다.

## 🛠️ 주요 작업 내용
   - 중복 계정 생성 방지 로직 추가
       - UsersService의 createUser 메서드에 사용자 계정(account)이 이미 존재하는지 확인하는 로직을 추가했습니다.
       - 중복이 발견될 경우, DUPLICATE_ACCOUNT 예외를 발생시켜 명확한 피드백을 제공합니다.

   - 데이터베이스 제약 조건 추가
       - UsersJpaEntity의 account 필드에 @Column(unique = true) 제약 조건을 추가하여 데이터베이스 수준에서 계정명의 유일성을 보장합니다.

   - 계정 기반 조회 기능 구현
       - 중복 확인 로직에 필요한 findUsersByAccount 메서드를 Repository 계층(UsersRepository, SpringDataJpaUsersRepository 등)에 
         추가했습니다.

## 🔗 관련 이슈

Resolves: #27 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention](https://www.notion.so/Git-1a10cae5674e813f8c60ebb4a8f99ca4?pvs=4#1aa0cae5674e807aa012d921c8fa6fe4) 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
