### PR TITLE
fix: 동시성 제어를 위한 낙관적 락(Optimistic Lock) 도입 및 관심사 분리를 위한 Facade 패턴 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/posicube/assignment/querylog/adapter/in/web/QueryLogController.java
+++ b/src/main/java/com/posicube/assignment/querylog/adapter/in/web/QueryLogController.java
@@ -2,7 +2,7 @@ package com.posicube.assignment.querylog.adapter.in.web;
 
 import com.posicube.assignment.querylog.application.commandquery.QueryRequest;
 import com.posicube.assignment.querylog.application.commandquery.QueryResponse;
-import com.posicube.assignment.querylog.application.service.QueryLogService;
+import com.posicube.assignment.querylog.application.facade.QueryLogFacade;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -11,12 +11,12 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/query")
 @RequiredArgsConstructor
 public class QueryLogController {
-    private final QueryLogService queryService;
+    private final QueryLogFacade queryLogFacade;
 
     @PostMapping
     public QueryResponse submitQuery(
             @RequestHeader("X-User-Id") Long userId,
             @Valid @RequestBody QueryRequest request) {
-        return queryService.submitQuery(userId, request);
+        return queryLogFacade.submitQuery(userId, request);
     }
 }

--- a/src/main/java/com/posicube/assignment/querylog/application/facade/QueryLogFacade.java
+++ b/src/main/java/com/posicube/assignment/querylog/application/facade/QueryLogFacade.java
@@ -36,10 +36,6 @@ public class QueryLogFacade {
                 lastException = e;
                 attempt++;
 
-                if (attempt >= MAX_RETRY) {
-                    break;
-                }
-
                 try {
                     Thread.sleep(RETRY_DELAY_MS * attempt);
                 } catch (InterruptedException ie) {
@@ -50,6 +46,6 @@ public class QueryLogFacade {
         }
 
         //3. 재시도 실패 시
-        throw new BaseException(QueryLogExceptionStatus.TOO_MANY_REQUESTS);
+        throw new BaseException(QueryLogExceptionStatus.TOO_MANY_CONCURRENT_REQUESTS);
     }
 }

--- a/src/main/java/com/posicube/assignment/querylog/application/facade/QueryLogFacade.java
+++ b/src/main/java/com/posicube/assignment/querylog/application/facade/QueryLogFacade.java
@@ -1,0 +1,55 @@
+package com.posicube.assignment.querylog.application.facade;
+
+import com.posicube.assignment.common.exception.BaseException;
+import com.posicube.assignment.querylog.application.commandquery.QueryRequest;
+import com.posicube.assignment.querylog.application.commandquery.QueryResponse;
+import com.posicube.assignment.querylog.application.service.QueryLogService;
+import com.posicube.assignment.querylog.application.service.RateLimiter;
+import com.posicube.assignment.querylog.exception.QueryLogExceptionStatus;
+import jakarta.persistence.OptimisticLockException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class QueryLogFacade {
+    private final QueryLogService queryLogService;
+    private final RateLimiter rateLimiter;
+
+    private static final int MAX_RETRY = 5;
+    private static final long RETRY_DELAY_MS = 50;
+
+    public QueryResponse submitQuery(Long userId, QueryRequest request) {
+        // 1. Rate Limit 먼저 체크 (재시도 전)
+        if (!rateLimiter.isAllowed(userId)) {
+            throw new BaseException(QueryLogExceptionStatus.TOO_MANY_REQUESTS);
+        }
+
+        // 2. 낙관 락 재시도 로직
+        int attempt = 0;
+        OptimisticLockException lastException = null;
+
+        while (attempt < MAX_RETRY) {
+            try {
+                return queryLogService.submitQuery(userId, request);
+            } catch (OptimisticLockException e) {
+                lastException = e;
+                attempt++;
+
+                if (attempt >= MAX_RETRY) {
+                    break;
+                }
+
+                try {
+                    Thread.sleep(RETRY_DELAY_MS * attempt);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(ie);
+                }
+            }
+        }
+
+        //3. 재시도 실패 시
+        throw new BaseException(QueryLogExceptionStatus.TOO_MANY_REQUESTS);
+    }
+}

--- a/src/main/java/com/posicube/assignment/querylog/application/service/QueryLogService.java
+++ b/src/main/java/com/posicube/assignment/querylog/application/service/QueryLogService.java
@@ -21,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class QueryLogService {
     private final QueryLogRepository queryLogRepository;
     private final UsersRepository usersRepository;
-    private final RateLimiter rateLimiter;
     private final LlmClient llmClient;
     private final TokenCalculator tokenCalculator;
 

--- a/src/main/java/com/posicube/assignment/querylog/application/service/QueryLogService.java
+++ b/src/main/java/com/posicube/assignment/querylog/application/service/QueryLogService.java
@@ -31,15 +31,10 @@ public class QueryLogService {
         Users user = usersRepository.findUserById(userId)
                 .orElseThrow(() -> new BaseException(UserExceptionStatus.USER_NOT_FOUND));
 
-        //2. Rate Limit 검증
-        if (!rateLimiter.isAllowed(userId)) {
-            throw new BaseException(QueryLogExceptionStatus.TOO_MANY_REQUESTS);
-        }
-
-        //3. 잔여 토큰 확인
+        //2. 잔여 토큰 확인
         user.validateQueryPermission();
 
-        //4. llm 호출
+        //3. llm 호출
         Long usedTokens = tokenCalculator.calculateTokensFromPrompt(request.q());
         String answer;
 
@@ -49,13 +44,13 @@ public class QueryLogService {
             throw new BaseException(QueryLogExceptionStatus.LLM_API_ERROR);
         }
 
-        //5. 토큰 사용
+        //4. 토큰 사용
         Users userWithTokensUsed = user.useTokens(usedTokens);
 
-        //6. 변경된 사용자 정보를 Repository에 전달하여 저장 (더티체킹x)
+        //5. 변경된 사용자 정보를 Repository에 전달하여 저장
         Users updatedUser = usersRepository.save(userWithTokensUsed);
 
-        //7. queryLog 저장
+        //6. queryLog 저장
         QueryLog queryLog = QueryLog.create(updatedUser, request.q(), ModelType.from(request.model()), answer, usedTokens);
         QueryLog saveQuery = queryLogRepository.save(queryLog);
 

--- a/src/main/java/com/posicube/assignment/querylog/exception/QueryLogExceptionStatus.java
+++ b/src/main/java/com/posicube/assignment/querylog/exception/QueryLogExceptionStatus.java
@@ -18,6 +18,7 @@ public enum QueryLogExceptionStatus implements ResponseStatus {
     USED_TOKEN_CANNOT_BE_NULL(false, "QUERY_LOG-7", "사용된 토큰은 null일 수 없습니다.", HttpStatus.BAD_REQUEST),
     LLM_API_ERROR(false, "QUERY_LOG-8", "LLM API 동작 중 에러가 발생하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     ANSWER_CANNOT_BE_NULL(false, "QUERY_LOG-9", "답변이 null일 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    TOO_MANY_CONCURRENT_REQUESTS(false, "QUERY_LOG-10", "동시 요청이 많습니다. 잠시 후 다시 시도해주세요.", HttpStatus.TOO_MANY_REQUESTS),
     ;
 
     private final boolean isSuccess;

--- a/src/main/java/com/posicube/assignment/users/adapter/out/persistence/UsersJpaEntity.java
+++ b/src/main/java/com/posicube/assignment/users/adapter/out/persistence/UsersJpaEntity.java
@@ -37,4 +37,7 @@ public class UsersJpaEntity {
 
     @Column(nullable = false)
     private long remainingTokens;
+
+    @Version
+    private Long version;
 }

--- a/src/main/java/com/posicube/assignment/users/adapter/out/persistence/UsersMapper.java
+++ b/src/main/java/com/posicube/assignment/users/adapter/out/persistence/UsersMapper.java
@@ -18,6 +18,7 @@ public class UsersMapper {
                 .password(entity.getPassword())
                 .name(entity.getName())
                 .tokens(tokens)
+                .version(entity.getVersion())
                 .build();
     }
 
@@ -32,6 +33,7 @@ public class UsersMapper {
                 .quota(domain.getTokens().getQuota())
                 .usedTokens(domain.getTokens().getUsedTokens())
                 .remainingTokens(domain.getTokens().getRemainingTokens())
+                .version(domain.getVersion())
                 .build();
     }
 }

--- a/src/main/java/com/posicube/assignment/users/domain/model/Users.java
+++ b/src/main/java/com/posicube/assignment/users/domain/model/Users.java
@@ -18,23 +18,25 @@ public class Users {
     private final String password;
     private final String name;
     private final Tokens tokens;
+    private final Long version;
 
     //1. 생성 전용 메서드: Service 계층에서 새로운 Users 만들때 사용
     static public Users create(String account, String password, String name, Plan plan) {
         Tokens initialledToken = Tokens.initialOf(plan);
         validateUserInvariants(account, password, name, initialledToken);
-        return new Users(null, plan.getType(), account, password, name, initialledToken);
+        return new Users(null, plan.getType(), account, password, name, initialledToken, null);
     }
 
     //2. 재구성 전용 builder: JPA Entity -> Domain 변환 시 사용
     @Builder(builderMethodName = "fromPersistenceBuilder")
-    private Users(Long id, PlanType planType, String account, String password, String name, Tokens tokens) {
+    private Users(Long id, PlanType planType, String account, String password, String name, Tokens tokens, Long version) {
         this.id = id;
         this.planType = planType;
         this.account = account;
         this.password = password;
         this.name = name;
         this.tokens = tokens;
+        this.version = version;
     }
 
     private static void validateUserInvariants(String account, String password, String name, Tokens tokens) {
@@ -63,7 +65,8 @@ public class Users {
                 this.account,
                 this.password,
                 this.name,
-                newTokens
+                newTokens,
+                this.version
         );
     }
 }

--- a/src/test/java/com/posicube/assignment/domain/querylog/QueryLogServiceTest.java
+++ b/src/test/java/com/posicube/assignment/domain/querylog/QueryLogServiceTest.java
@@ -6,6 +6,7 @@ import com.posicube.assignment.plan.domain.model.Plan;
 import com.posicube.assignment.plan.domain.model.PlanType;
 import com.posicube.assignment.querylog.application.commandquery.QueryRequest;
 import com.posicube.assignment.querylog.application.commandquery.QueryResponse;
+import com.posicube.assignment.querylog.application.facade.QueryLogFacade;
 import com.posicube.assignment.querylog.application.service.QueryLogService;
 import com.posicube.assignment.querylog.application.service.RateLimiter;
 import com.posicube.assignment.querylog.domain.model.QueryLog;
@@ -48,6 +49,8 @@ public class QueryLogServiceTest {
 
     @InjectMocks
     QueryLogService queryService;
+    @InjectMocks
+    QueryLogFacade queryLogFacade;
 
     private Users mockUser;
     private QueryRequest mockRequest;
@@ -74,11 +77,10 @@ public class QueryLogServiceTest {
     @DisplayName("submitQuery: Rate Limit를 초과하면 예외를 던진다.")
     public void submitQuery_rateLimit_fail() {
         //given: RateLimiter가 항상 요청 거부
-        when(usersRepository.findUserById(1L)).thenReturn(Optional.of(mockUser));
         when(rateLimiter.isAllowed(1L)).thenReturn(false);
 
         //when&then: 서비스 실행 시 예외 검증
-        assertThatThrownBy(() -> queryService.submitQuery(1L, mockRequest))
+        assertThatThrownBy(() -> queryLogFacade.submitQuery(1L, mockRequest))
                 .isInstanceOf(BaseException.class)
                 .hasMessage(QueryLogExceptionStatus.TOO_MANY_REQUESTS.getMessage());
     }
@@ -92,7 +94,6 @@ public class QueryLogServiceTest {
         ReflectionTestUtils.setField(mockUser, "tokens", zeroToken);
 
         when(usersRepository.findUserById(1L)).thenReturn(Optional.of(mockUser));
-        when(rateLimiter.isAllowed(1L)).thenReturn(true);
 
         //then: 서비스 실행 시 예외 검증
         assertThatThrownBy(() -> queryService.submitQuery(1L, mockRequest))
@@ -105,7 +106,6 @@ public class QueryLogServiceTest {
     public void submitQuery_llmClientResponse_success() {
         //given: 모든 의존성이 정상적으로 동작하도록 설정
         when(usersRepository.findUserById(1L)).thenReturn(Optional.of(mockUser));
-        when(rateLimiter.isAllowed(1L)).thenReturn(true);
         when(llmClient.query(anyString(), anyString())).thenReturn("모델 gpt-5 로부터의 응답: query 에 대한 답변입니다.");
         when(queryLogRepository.save(any(QueryLog.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(usersRepository.save(any(Users.class))).thenAnswer(invocation -> invocation.getArgument(0));
@@ -126,7 +126,6 @@ public class QueryLogServiceTest {
         long expectedUsedTokens = new TokenCalculator().calculateTokensFromPrompt(mockRequest.q());
 
         when(usersRepository.findUserById(1L)).thenReturn(Optional.of(mockUser));
-        when(rateLimiter.isAllowed(1L)).thenReturn(true);
         when(llmClient.query(anyString(), anyString())).thenReturn("모델 gpt-5 로부터의 응답: query 에 대한 답변입니다.");
         when(tokenCalculator.calculateTokensFromPrompt(mockRequest.q())).thenReturn(expectedUsedTokens);
         when(queryLogRepository.save(any(QueryLog.class))).thenAnswer(invocation -> invocation.getArgument(0));
@@ -161,7 +160,6 @@ public class QueryLogServiceTest {
         long expectedUsedTokens = 75L;
 
         when(usersRepository.findUserById(1L)).thenReturn(Optional.of(spy));
-        when(rateLimiter.isAllowed(1L)).thenReturn(true);
         when(llmClient.query(anyString(), anyString())).thenReturn("i".repeat(100));
         when(queryLogRepository.save(any(QueryLog.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(usersRepository.save(any(Users.class))).thenAnswer(invocation -> invocation.getArgument(0));
@@ -184,7 +182,6 @@ public class QueryLogServiceTest {
     public void submitQuery_llmClient_fail() {
         //given: LLM 클라이언트 호출 시 예외 발생 설정
         when(usersRepository.findUserById(1L)).thenReturn(Optional.of(mockUser));
-        when(rateLimiter.isAllowed(1L)).thenReturn(true);
         when(llmClient.query(anyString(), anyString())).thenThrow(new RuntimeException("외부 API 호출 중 오류가 발생했습니다"));
 
         //when&then: 서비스 실행 시 예외 발생 검증

--- a/src/test/java/com/posicube/assignment/domain/users/UserServiceConcurrencyTest.java
+++ b/src/test/java/com/posicube/assignment/domain/users/UserServiceConcurrencyTest.java
@@ -1,0 +1,148 @@
+package com.posicube.assignment.domain.users;
+
+import com.posicube.assignment.LlmClient;
+import com.posicube.assignment.plan.domain.model.Plan;
+import com.posicube.assignment.plan.domain.model.PlanType;
+import com.posicube.assignment.querylog.application.commandquery.QueryRequest;
+import com.posicube.assignment.querylog.application.facade.QueryLogFacade;
+import com.posicube.assignment.users.domain.model.Users;
+import com.posicube.assignment.users.port.UsersRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+public class UserServiceConcurrencyTest {
+    private static final Logger log = LoggerFactory.getLogger(UserServiceConcurrencyTest.class);
+    @Autowired
+    private QueryLogFacade queryLogFacade;
+
+    @Autowired
+    private UsersRepository usersRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @MockBean
+    private LlmClient llmClient;
+
+    private Users testUser;
+
+    @BeforeEach
+    void setUp() {
+        // LLM 클라이언트 Mock 설정
+        when(llmClient.query(any(), any())).thenReturn("i".repeat(100));  // 100자(문자길이) * 0.75 = 75토큰
+
+        TransactionStatus transaction = transactionManager.getTransaction(
+                new DefaultTransactionDefinition()
+        );
+        try {
+            Users users = Users.create("test1", "pass1234", "evan", Plan.create(PlanType.LITE));
+            testUser = usersRepository.save(users);
+
+            entityManager.flush();
+
+            entityManager.createQuery(
+                            "UPDATE UsersJpaEntity u SET u.remainingTokens = :tokens WHERE u.id = :id"
+                    )
+                    .setParameter("tokens", 7500L)
+                    .setParameter("id", testUser.getId())
+                    .executeUpdate();
+
+            transactionManager.commit(transaction);
+        } catch (Exception e) {
+            transactionManager.rollback(transaction);
+            throw e;
+        }
+
+        entityManager.clear();
+    }
+
+    @Test
+    @DisplayName("낙관 락 적용: 동시 요청 시에도 토큰 차감을 정확하게 처리한다.")
+    public void token_deduction_race_condition_test() throws Exception {
+        // given
+        int concurrentUsers = 100;
+        long expectedTokensPerRequest = 75;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(concurrentUsers);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        Users verifyUser = usersRepository.findUserById(testUser.getId())
+                .orElseThrow(() -> new RuntimeException("테스트 사용자가 존재하지 않습니다"));
+        long initialTokens = verifyUser.getTokens().getRemainingTokens();
+
+//        log.info("테스트 시작 - 사용자 ID: {}, 초기 토큰: {}", verifyUser.getId(), initialTokens);
+
+        QueryRequest queryRequest = new QueryRequest("i".repeat(100), "gpt-5");
+
+        // when: 100개 동시 요청 실행
+        for (int i = 0; i < concurrentUsers; i++) {
+            final int reqNum = i;
+            executorService.submit(() -> {
+                try {
+                    queryLogFacade.submitQuery(testUser.getId(), queryRequest);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+//                    log.error("Thread {} - Request {}: 최종 실패 - {}", Thread.currentThread().getName(), reqNum, e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+        boolean terminated = executorService.awaitTermination(10, TimeUnit.SECONDS);
+        assertThat(terminated).isTrue();
+
+        // then: 결과 검증
+        Thread.sleep(100);
+        Users userAfterEvent = usersRepository.findUserById(testUser.getId())
+                .orElseThrow(() -> new RuntimeException("테스트 사용자가 존재하지 않습니다"));
+        long finalTokens = userAfterEvent.getTokens().getRemainingTokens();
+        long expectedFinalToken = initialTokens - (successCount.get() * expectedTokensPerRequest);
+
+//        log.info("========== 테스트 결과 ==========");
+//        log.info("총 요청 수: {}", concurrentUsers);
+//        log.info("성공한 요청: {}", successCount.get());
+//        log.info("실패한 요청: {}", failCount.get());
+//        log.info("초기 토큰: {}", initialTokens);
+//        log.info("최종 토큰: {}", finalTokens);
+//        log.info("기대했던 최종 토큰: {}", expectedFinalToken);
+//        log.info("================================");
+
+        // 검증 1: 최종 토큰 수가 예상과 정확히 일치해야 한다.
+        assertThat(finalTokens).isEqualTo(expectedFinalToken);
+
+        // 검증 2: 추가 검증 - 성공+실패 = 총 요청
+        assertThat(successCount.get() + failCount.get()).isEqualTo(concurrentUsers);
+
+        // 검증 3: Rate Limiter 동작 검증
+        assertThat(successCount.get()).isLessThanOrEqualTo(30);
+    }
+}

--- a/src/test/java/com/posicube/assignment/domain/users/UserServiceConcurrencyTest.java
+++ b/src/test/java/com/posicube/assignment/domain/users/UserServiceConcurrencyTest.java
@@ -15,7 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
@@ -45,7 +45,7 @@ public class UserServiceConcurrencyTest {
     @Autowired
     private PlatformTransactionManager transactionManager;
 
-    @MockBean
+    @MockitoBean
     private LlmClient llmClient;
 
     private Users testUser;


### PR DESCRIPTION
## 🚀 개요
동시성 제어를 위한 낙관적 락(Optimistic Lock) 도입 및 관심사 분리를 위한 Facade 패턴 적용

## 🛠️ 주요 작업 내용
### 1. 낙관적 락(Optimistic Lock) 적용

- **Users 엔티티에 `@Version` 필드 추가**
    - 동시성 제어를 위한 버전 관리 메커니즘 도입
    - `OptimisticLockException` 발생 시 재시도 로직으로 처리

### 2. Facade 패턴을 통한 관심사 분리

- **QueryLogFacade 신규 추가**
    - Rate Limiting: 외부 트래픽 제어 (재시도와 무관하게 최초 1회만 검증)
    - Retry Logic: 낙관적 락 충돌 시 재시도 처리 (최대 5회, 지수 백오프)
    - 횡단 관심사와 비즈니스 로직의 명확한 분리
- **QueryLogService 리팩토링**
    - Rate Limit 검증 로직 제거 → Facade로 이동
    - 순수한 비즈니스 로직만 담당 (토큰 차감, LLM 호출, 저장)
- **QueryLogController 수정**
    - QueryLogService → QueryLogFacade 호출로 변경
    - 진입점에서 횡단 관심사 처리

### 3. 테스트 코드 추가 및 개선

- **UserServiceConcurrencyTest 추가**
    - 100개 동시 요청으로 낙관적 락 동작 검증
    - 토큰 차감 정합성 테스트
    - 성공/실패 카운트 및 최종 토큰 수 검증
- **Deprecated 애너테이션 마이그레이션**
    - `@MockBean` → `@MockitoBean` (Spring Boot 3.4.0+)
    - `@SpyBean` → `@MockitoSpyBean`

### 4. 빌드 설정

- **Spring AOP 의존성 추가**
    - `spring-boot-starter-aop`: `@Version` 지원

## 🎯 아키텍처 개선 효과

### Before

```
Controller → Service (Rate Limit + 비즈니스 로직)
- 횡단 관심사와 비즈니스 로직 혼재
- 재시도 시 Rate Limit 재검증 문제
```

### After

```
Controller → Facade (Rate Limit + Retry) → Service (비즈니스 로직)
- 관심사의 명확한 분리
- Rate Limit은 외부 트래픽만 카운트 (재시도 제외)
- Service는 순수 비즈니스 로직에 집중
```

## 📝 Rate Limiting 정책

- **목적**: 사용자 API 남용 방지 (외부 트래픽 제어)
- **카운트 대상**: HTTP 요청 (사용자가 보낸 실제 API 호출)
- **재시도 정책**: 재시도는 시스템 내부 복구이므로 카운트 안함
- **근거**: 요구사항 "사용자별 분당 요청 횟수 제한"

## 🔗 관련 이슈
Resolves: #32

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention](https://www.notion.so/Git-1a10cae5674e813f8c60ebb4a8f99ca4?pvs=4#1aa0cae5674e807aa012d921c8fa6fe4) 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
