### PR TITLE
refactor: InMemoryRateLimiter에 Caffeine 캐시 적용하여 성능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation("com.github.ben-manes.caffeine:caffeine:3.2.3")
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/posicube/assignment/querylog/application/service/InMemoryRateLimiterWithCaffeine.java
+++ b/src/main/java/com/posicube/assignment/querylog/application/service/InMemoryRateLimiterWithCaffeine.java
@@ -1,19 +1,36 @@
 package com.posicube.assignment.querylog.application.service;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.Deque;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Component
-public class InMemoryRateLimiter implements RateLimiter {
+public class InMemoryRateLimiterWithCaffeine implements RateLimiter {
     private static final int MAX_REQUEST = 30;
     private static final int TIME_WINDOW_IN_MINUTE = 1;
+    private static final int CACHE_EXPIRE_MINUTES = 5;
+    private static final int MAX_CACHE_SIZE = 10_000;
 
-    private final Map<Long, Deque<LocalDateTime>> requestTimestamp = new ConcurrentHashMap<>();
+    private final Cache<Long, Deque<LocalDateTime>> requestTimestamp;
+
+    public InMemoryRateLimiterWithCaffeine() {
+        this.requestTimestamp = Caffeine.newBuilder()
+                .maximumSize(MAX_CACHE_SIZE)
+                .expireAfterAccess(CACHE_EXPIRE_MINUTES, TimeUnit.MINUTES)
+                .recordStats()
+                .removalListener((Long userId, Deque<LocalDateTime> value, RemovalCause cause) -> {
+                    log.debug("사용자 {}, 데이터 제거 (원인: {})", userId, cause);
+                })
+                .build();
+    }
 
     @Override
     public boolean isAllowed(Long userId) {
@@ -21,7 +38,9 @@ public class InMemoryRateLimiter implements RateLimiter {
         LocalDateTime windowStart = now.minusMinutes(TIME_WINDOW_IN_MINUTE);
 
         // 1. 해당 사용자의 요청 기록 큐를 가져온다. 없으면 새로 생성
-        Deque<LocalDateTime> userTimestamp = requestTimestamp.computeIfAbsent(userId, k -> new ConcurrentLinkedDeque<>());
+        Deque<LocalDateTime> userTimestamp
+                = requestTimestamp.get(userId,
+                k -> new ConcurrentLinkedDeque<>());
 
         // 2. 동기화 블록으로 특정 사용자의 큐에 대한 동시 접근을 막는다.
         synchronized (userTimestamp) {


### PR DESCRIPTION
## 🚀 개요
 기존 InMemoryRateLimiter는 ConcurrentHashMap을 사용하여 사용자의 요청 횟수를 기록했습니다. 동시성 환경에서 더 안정적이고 효율적인 처리를 위해, 만료 정책을 자체적으로 관리해주는 Caffeine 캐시를 도입하여 성능을 개선하고 코드의 복잡도를 낮추었습니다.

## 🛠️ 주요 작업 내용
   - Caffeine 의존성 추가
       - build.gradle에 spring-boot-starter-cache 및 caffeine 라이브러리 의존성을 추가했습니다.
   - InMemoryRateLimiter 리팩토링
       - 요청 횟수를 저장하는 자료구조를 ConcurrentHashMap에서 Caffeine Cache로 변경했습니다.
       - Caffeine의 expireAfterWrite 설정을 통해 5분 후 데이터가 자동으로 만료되도록 하여, 수동으로 만료 데이터를 처리하는 로직을 제거했습니다.

## 🔗 관련 이슈
Resolves: #34 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention](https://www.notion.so/Git-1a10cae5674e813f8c60ebb4a8f99ca4?pvs=4#1aa0cae5674e807aa012d921c8fa6fe4) 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
