### PR TITLE
refactor: LLMClient 의존성 역전 구현

### DIFF
--- a/src/main/java/com/posicube/assignment/querylog/adapter/out/external/LlmClient.java
+++ b/src/main/java/com/posicube/assignment/querylog/adapter/out/external/LlmClient.java
@@ -1,11 +1,12 @@
-package com.posicube.assignment;
+package com.posicube.assignment.querylog.adapter.out.external;
 
+import com.posicube.assignment.querylog.port.LlmPort;
 import org.springframework.stereotype.Component;
 
 import java.util.Random;
 
 @Component
-public class LlmClient {
+public class LlmClient implements LlmPort {
     private final Random random = new Random();
 
     public String query(String query, String model) {

--- a/src/main/java/com/posicube/assignment/querylog/adapter/out/persistence/QueryLogJpaEntity.java
+++ b/src/main/java/com/posicube/assignment/querylog/adapter/out/persistence/QueryLogJpaEntity.java
@@ -30,7 +30,7 @@ public class QueryLogJpaEntity {
     @Column(nullable = false)
     private ModelType type;
 
-    @Column(nullable = false, length = 3000)
+    @Column(nullable = false, length = 3000)  //유연하게 크게 설정
     private String content;
 
     @Column(nullable = false)

--- a/src/main/java/com/posicube/assignment/querylog/adapter/out/persistence/QueryLogRepositoryImpl.java
+++ b/src/main/java/com/posicube/assignment/querylog/adapter/out/persistence/QueryLogRepositoryImpl.java
@@ -2,7 +2,7 @@ package com.posicube.assignment.querylog.adapter.out.persistence;
 
 import com.posicube.assignment.common.exception.BaseException;
 import com.posicube.assignment.querylog.domain.model.QueryLog;
-import com.posicube.assignment.querylog.port.out.QueryLogRepository;
+import com.posicube.assignment.querylog.port.QueryLogRepository;
 import com.posicube.assignment.users.adapter.out.persistence.SpringDataJpaUsersRepository;
 import com.posicube.assignment.users.adapter.out.persistence.UsersJpaEntity;
 import com.posicube.assignment.users.exception.UserExceptionStatus;

--- a/src/main/java/com/posicube/assignment/querylog/application/service/QueryLogService.java
+++ b/src/main/java/com/posicube/assignment/querylog/application/service/QueryLogService.java
@@ -1,6 +1,5 @@
 package com.posicube.assignment.querylog.application.service;
 
-import com.posicube.assignment.LlmClient;
 import com.posicube.assignment.common.exception.BaseException;
 import com.posicube.assignment.querylog.application.commandquery.QueryRequest;
 import com.posicube.assignment.querylog.application.commandquery.QueryResponse;
@@ -8,7 +7,8 @@ import com.posicube.assignment.querylog.domain.model.ModelType;
 import com.posicube.assignment.querylog.domain.model.QueryLog;
 import com.posicube.assignment.querylog.domain.policy.TokenCalculator;
 import com.posicube.assignment.querylog.exception.QueryLogExceptionStatus;
-import com.posicube.assignment.querylog.port.out.QueryLogRepository;
+import com.posicube.assignment.querylog.port.LlmPort;
+import com.posicube.assignment.querylog.port.QueryLogRepository;
 import com.posicube.assignment.users.domain.model.Users;
 import com.posicube.assignment.users.exception.UserExceptionStatus;
 import com.posicube.assignment.users.port.UsersRepository;
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class QueryLogService {
     private final QueryLogRepository queryLogRepository;
     private final UsersRepository usersRepository;
-    private final LlmClient llmClient;
+    private final LlmPort llmPort;
     private final TokenCalculator tokenCalculator;
 
     @Transactional
@@ -38,7 +38,7 @@ public class QueryLogService {
         String answer;
 
         try {
-            answer = llmClient.query(request.q(), request.model());
+            answer = llmPort.query(request.q(), request.model());
         } catch (Exception e) {
             throw new BaseException(QueryLogExceptionStatus.LLM_API_ERROR);
         }

--- a/src/main/java/com/posicube/assignment/querylog/port/LlmPort.java
+++ b/src/main/java/com/posicube/assignment/querylog/port/LlmPort.java
@@ -1,0 +1,5 @@
+package com.posicube.assignment.querylog.port;
+
+public interface LlmPort {
+    String query(String query, String model);
+}

--- a/src/main/java/com/posicube/assignment/querylog/port/QueryLogRepository.java
+++ b/src/main/java/com/posicube/assignment/querylog/port/QueryLogRepository.java
@@ -1,4 +1,4 @@
-package com.posicube.assignment.querylog.port.out;
+package com.posicube.assignment.querylog.port;
 
 import com.posicube.assignment.querylog.domain.model.QueryLog;
 

--- a/src/main/java/com/posicube/assignment/users/application/service/UsersService.java
+++ b/src/main/java/com/posicube/assignment/users/application/service/UsersService.java
@@ -5,7 +5,7 @@ import com.posicube.assignment.plan.application.service.PlanService;
 import com.posicube.assignment.plan.domain.model.Plan;
 import com.posicube.assignment.plan.domain.model.PlanType;
 import com.posicube.assignment.querylog.domain.model.QueryLog;
-import com.posicube.assignment.querylog.port.out.QueryLogRepository;
+import com.posicube.assignment.querylog.port.QueryLogRepository;
 import com.posicube.assignment.users.application.commandquery.UsageResponse;
 import com.posicube.assignment.users.application.commandquery.UserCreateRequest;
 import com.posicube.assignment.users.application.commandquery.UserInfoResponse;

--- a/src/test/java/com/posicube/assignment/domain/querylog/QueryLogServiceTest.java
+++ b/src/test/java/com/posicube/assignment/domain/querylog/QueryLogServiceTest.java
@@ -1,18 +1,18 @@
 package com.posicube.assignment.domain.querylog;
 
-import com.posicube.assignment.LlmClient;
 import com.posicube.assignment.common.exception.BaseException;
 import com.posicube.assignment.plan.domain.model.Plan;
 import com.posicube.assignment.plan.domain.model.PlanType;
 import com.posicube.assignment.querylog.application.commandquery.QueryRequest;
 import com.posicube.assignment.querylog.application.commandquery.QueryResponse;
 import com.posicube.assignment.querylog.application.facade.QueryLogFacade;
+import com.posicube.assignment.querylog.port.LlmPort;
 import com.posicube.assignment.querylog.application.service.QueryLogService;
 import com.posicube.assignment.querylog.application.service.RateLimiter;
 import com.posicube.assignment.querylog.domain.model.QueryLog;
 import com.posicube.assignment.querylog.domain.policy.TokenCalculator;
 import com.posicube.assignment.querylog.exception.QueryLogExceptionStatus;
-import com.posicube.assignment.querylog.port.out.QueryLogRepository;
+import com.posicube.assignment.querylog.port.QueryLogRepository;
 import com.posicube.assignment.users.domain.model.Tokens;
 import com.posicube.assignment.users.domain.model.Users;
 import com.posicube.assignment.users.exception.TokenExceptionStatus;
@@ -41,7 +41,7 @@ public class QueryLogServiceTest {
     @Mock
     QueryLogRepository queryLogRepository;
     @Mock
-    LlmClient llmClient;
+    LlmPort llmPort;
     @Mock
     RateLimiter rateLimiter;
     @Mock
@@ -106,7 +106,7 @@ public class QueryLogServiceTest {
     public void submitQuery_llmClientResponse_success() {
         //given: 모든 의존성이 정상적으로 동작하도록 설정
         when(usersRepository.findUserById(1L)).thenReturn(Optional.of(mockUser));
-        when(llmClient.query(anyString(), anyString())).thenReturn("모델 gpt-5 로부터의 응답: query 에 대한 답변입니다.");
+        when(llmPort.query(anyString(), anyString())).thenReturn("모델 gpt-5 로부터의 응답: query 에 대한 답변입니다.");
         when(queryLogRepository.save(any(QueryLog.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(usersRepository.save(any(Users.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -126,7 +126,7 @@ public class QueryLogServiceTest {
         long expectedUsedTokens = new TokenCalculator().calculateTokensFromPrompt(mockRequest.q());
 
         when(usersRepository.findUserById(1L)).thenReturn(Optional.of(mockUser));
-        when(llmClient.query(anyString(), anyString())).thenReturn("모델 gpt-5 로부터의 응답: query 에 대한 답변입니다.");
+        when(llmPort.query(anyString(), anyString())).thenReturn("모델 gpt-5 로부터의 응답: query 에 대한 답변입니다.");
         when(tokenCalculator.calculateTokensFromPrompt(mockRequest.q())).thenReturn(expectedUsedTokens);
         when(queryLogRepository.save(any(QueryLog.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(usersRepository.save(any(Users.class))).thenAnswer(invocation -> invocation.getArgument(0));
@@ -160,7 +160,7 @@ public class QueryLogServiceTest {
         long expectedUsedTokens = 75L;
 
         when(usersRepository.findUserById(1L)).thenReturn(Optional.of(spy));
-        when(llmClient.query(anyString(), anyString())).thenReturn("i".repeat(100));
+        when(llmPort.query(anyString(), anyString())).thenReturn("i".repeat(100));
         when(queryLogRepository.save(any(QueryLog.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(usersRepository.save(any(Users.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(tokenCalculator.calculateTokensFromPrompt(mockRequest.q())).thenReturn(expectedUsedTokens);
@@ -182,7 +182,7 @@ public class QueryLogServiceTest {
     public void submitQuery_llmClient_fail() {
         //given: LLM 클라이언트 호출 시 예외 발생 설정
         when(usersRepository.findUserById(1L)).thenReturn(Optional.of(mockUser));
-        when(llmClient.query(anyString(), anyString())).thenThrow(new RuntimeException("외부 API 호출 중 오류가 발생했습니다"));
+        when(llmPort.query(anyString(), anyString())).thenThrow(new RuntimeException("외부 API 호출 중 오류가 발생했습니다"));
 
         //when&then: 서비스 실행 시 예외 발생 검증
         assertThatThrownBy(() -> queryService.submitQuery(1L, mockRequest))

--- a/src/test/java/com/posicube/assignment/domain/users/UserServiceConcurrencyTest.java
+++ b/src/test/java/com/posicube/assignment/domain/users/UserServiceConcurrencyTest.java
@@ -1,10 +1,10 @@
 package com.posicube.assignment.domain.users;
 
-import com.posicube.assignment.LlmClient;
 import com.posicube.assignment.plan.domain.model.Plan;
 import com.posicube.assignment.plan.domain.model.PlanType;
 import com.posicube.assignment.querylog.application.commandquery.QueryRequest;
 import com.posicube.assignment.querylog.application.facade.QueryLogFacade;
+import com.posicube.assignment.querylog.port.LlmPort;
 import com.posicube.assignment.users.domain.model.Users;
 import com.posicube.assignment.users.port.UsersRepository;
 import jakarta.persistence.EntityManager;
@@ -46,14 +46,14 @@ public class UserServiceConcurrencyTest {
     private PlatformTransactionManager transactionManager;
 
     @MockitoBean
-    private LlmClient llmClient;
+    private LlmPort llmPort;
 
     private Users testUser;
 
     @BeforeEach
     void setUp() {
         // LLM 클라이언트 Mock 설정
-        when(llmClient.query(any(), any())).thenReturn("i".repeat(100));  // 100자(문자길이) * 0.75 = 75토큰
+        when(llmPort.query(any(), any())).thenReturn("i".repeat(100));  // 100자(문자길이) * 0.75 = 75토큰
 
         TransactionStatus transaction = transactionManager.getTransaction(
                 new DefaultTransactionDefinition()


### PR DESCRIPTION
## 🚀 개요
LlmClientService interface를 구현하여 의존역을 역전시키고 다른 LlmClient가 도입되더라도 interface만 구현하면 작동할 수 있도록 표준화 시킨다.

## ⛏️ 상세 작업 내용
- LLM 클라이언트 의존성 역전: 기존 LlmClient 클래스를 LlmPort 인터페이스를 구현하도록 변경하고, QueryLogService가 이 인터페이스에 의존하도록 수정하여 LLM 클라이언트의 의존성을 역전시켰습니다.
- 새로운 인터페이스 도입: querylog.port 패키지에 LlmPort 인터페이스를 새로 추가하여 LLM 클라이언트의 추상화된 계약을 정의했습니다.
- 패키지 및 파일 구조 변경: LlmClient 클래스와 QueryLogRepository 인터페이스의 패키지 경로를 변경하고, 이에 따라 관련 파일들의 import 문을 업데이트했습니다.
- 테스트 코드 업데이트: 변경된 의존성 구조에 맞춰 QueryLogServiceTest와 UserServiceConcurrencyTest에서 LlmClient 목 객체 대신 LlmPort 목 객체를 사용하도록 수정했습니다.
- 데이터베이스 컬럼 주석 추가: QueryLogJpaEntity의 content 컬럼에 length를 유연하게 설정한다는 주석을 추가했습니다.

## 🛠️ 주요 작업 내용
   - LlmClientService interface를 구현합니다.
   - Test코드 수정합니다.

## 🔗 관련 이슈

Resolves: #38

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention](https://www.notion.so/Git-1a10cae5674e813f8c60ebb4a8f99ca4?pvs=4#1aa0cae5674e807aa012d921c8fa6fe4) 참고  (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
